### PR TITLE
Add converting and benchmark process

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ python train.py --data coco.yaml --epochs 300 --weights '' --cfg ./models/yolo-f
 
 ## 3. Compress model and export to onnx with PyNetsPresso
 
-`auto_process.py` provides integrated process which contains torch.fx converting, model compression, fx model retraining, and onnx exporting. You can execute `auto_process.py` with minimal training hyper-parameters and NetsPresso account information.
+`auto_process.py` provides integrated process which contains torch.fx converting, model compression, fx model retraining, onnx exporting, tflite converting, and device benchmark. You can execute `auto_process.py` with minimal training hyper-parameters and NetsPresso account information.
 
+You can choose Renesas-RA8D1 or Ensemble-E7-DevKit-Gen2 device, and boost inference speed by giving helium option.
 ``` bash
-python auto_process.py --data coco.yaml --name yolo_fastest --weight_path ./models/yolo_fastest_uadetrac_256.pt --epochs 300 --batch-size 128 --np_email '' --np_password ''
+python auto_process.py --data coco.yaml --name yolo_fastest --weight_path ./models/yolo_fastest_uadetrac_256.pt --epochs 300 --batch-size 128 --np_email '' --np_password '' --target_device Renesas-RA8D1 --helium
 ```
 </br>
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python train.py --data coco.yaml --epochs 300 --weights '' --cfg ./models/yolo-f
 
 `auto_process.py` provides integrated process which contains torch.fx converting, model compression, fx model retraining, onnx exporting, tflite converting, and device benchmark. You can execute `auto_process.py` with minimal training hyper-parameters and NetsPresso account information.
 
-You can choose Renesas-RA8D1 (Arm Cortex-M85) or Ensemble-E7-DevKit-Gen2 (Arm Cortex-M55 + Ethos-U55) device, and boost inference speed by giving helium option.
+You can choose Renesas-RA8D1 (Arm Cortex-M85) or Ensemble-E7-DevKit-Gen2 (Arm Cortex-M55 + Ethos-U55) device, and boost inference speed by giving Helium option.
 ``` bash
 python auto_process.py --data coco.yaml --name yolo_fastest --weight_path ./models/yolo_fastest_uadetrac_256.pt --epochs 300 --batch-size 128 --np_email '' --np_password '' --target_device Renesas-RA8D1 --helium
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python train.py --data coco.yaml --epochs 300 --weights '' --cfg ./models/yolo-f
 
 `auto_process.py` provides integrated process which contains torch.fx converting, model compression, fx model retraining, onnx exporting, tflite converting, and device benchmark. You can execute `auto_process.py` with minimal training hyper-parameters and NetsPresso account information.
 
-You can choose Renesas-RA8D1 or Ensemble-E7-DevKit-Gen2 device, and boost inference speed by giving helium option.
+You can choose Renesas-RA8D1 (Arm Cortex-M85) or Ensemble-E7-DevKit-Gen2 (Arm Cortex-M55 + Ethos-U55) device, and boost inference speed by giving helium option.
 ``` bash
 python auto_process.py --data coco.yaml --name yolo_fastest --weight_path ./models/yolo_fastest_uadetrac_256.pt --epochs 300 --batch-size 128 --np_email '' --np_password '' --target_device Renesas-RA8D1 --helium
 ```

--- a/auto_process.py
+++ b/auto_process.py
@@ -39,7 +39,7 @@ def parse_args():
     parser.add_argument('--hyp', type=str, default='data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')
     parser.add_argument('--epochs', type=int, default=100, help='total training epochs')
     parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs, -1 for autobatch')
-    parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='train, val image size (pixels)')
+    parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=256, help='train, val image size (pixels)')
     parser.add_argument('--rect', action='store_true', help='rectangular training')
     parser.add_argument('--resume', nargs='?', const=True, default=False, help='resume most recent training')
     parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')

--- a/auto_process.py
+++ b/auto_process.py
@@ -7,7 +7,19 @@ import torch
 import torch.fx as fx
 from loguru import logger
 
+from netspresso.client import SessionClient
 from netspresso.compressor import ModelCompressor, Task, Framework
+from netspresso.launcher import (
+    ModelConverter,
+    ModelBenchmarker,
+    ModelFramework,
+    DeviceName,
+    BenchmarkTask,
+    ConversionTask,
+    Model,
+    DataType,
+    HardwareType,
+)
 
 import train
 from export import run
@@ -86,6 +98,13 @@ if __name__ == '__main__':
     if args.export_half:
         assert args.device != 'cpu', "Cannot export model to fp16 onnx with cpu mode!!"
 
+    """
+        Log in to NetsPresso
+    """
+    session = SessionClient(email=args.np_email, password=args.np_password)
+    compressor = ModelCompressor(user_session=session)
+    converter = ModelConverter(user_session=session)
+
     """ 
         Convert YOLO_Fastest model to fx 
     """
@@ -119,8 +138,6 @@ if __name__ == '__main__':
         Model compression - recommendation compression 
     """
     logger.info("Compression step start.")
-    
-    compressor = ModelCompressor(email=args.np_email, password=args.np_password)
 
     UPLOAD_MODEL_NAME = args.name
     TASK = Task.OBJECT_DETECTION

--- a/auto_process.py
+++ b/auto_process.py
@@ -76,7 +76,7 @@ def parse_args():
     """
         Export arguments
     """
-    parser.add_argument('--export_half', action='store_true', default=True, help='Entity')
+    parser.add_argument('--export_half', action='store_true', default=False, help='Entity')
 
     return parser.parse_args()
 

--- a/auto_process.py
+++ b/auto_process.py
@@ -90,6 +90,12 @@ def parse_args():
     """
     parser.add_argument('--export_half', action='store_true', default=False, help='Entity')
 
+    """
+        Converting and benchmark arguments
+    """
+    parser.add_argument('--target_device', type=str, choices=["Renesas-RA8D1", "Ensemble-E7-DevKit-Gen2"], default="Renesas-RA8D1")
+    parser.add_argument('--helium', action='store_true', default=False)
+
     return parser.parse_args()
 
 
@@ -225,7 +231,7 @@ if __name__ == '__main__':
     """
     logger.info("Converting model to tflite step start.")
 
-    TARGET_DEVICE_NAME = DeviceName.RENESAS_RA8D1
+    TARGET_DEVICE_NAME = args.target_device
     DATA_TYPE = DataType.INT8
 
     model: Model = converter.upload_model(onnx_model)
@@ -250,13 +256,16 @@ if __name__ == '__main__':
     """
     logger.info("Benchmark step start.")
 
+    hardware_type = HardwareType.HELIUM if args.helium else None
+
     benchmark_model: Model = benchmarker.upload_model(tflite_model)
     benchmark_task: BenchmarkTask = benchmarker.benchmark_model(
         model=benchmark_model,
         target_device_name=TARGET_DEVICE_NAME,
         data_type=DATA_TYPE,
-        hardware_type=HardwareType.HELIUM,
+        hardware_type=hardware_type,
         wait_until_done=True
     )
 
+    logger.info("Benchmark step end.")
     logger.info(f"model inference latency: {benchmark_task.latency} ms")

--- a/auto_process.py
+++ b/auto_process.py
@@ -104,6 +104,7 @@ if __name__ == '__main__':
     session = SessionClient(email=args.np_email, password=args.np_password)
     compressor = ModelCompressor(user_session=session)
     converter = ModelConverter(user_session=session)
+    benchmarker = ModelBenchmarker(user_session=session)
 
     """ 
         Convert YOLO_Fastest model to fx 
@@ -243,3 +244,19 @@ if __name__ == '__main__':
     converter.download_converted_model(conversion_task, dst=tflite_model)
 
     logger.info("Converting model to tflite step end.")
+
+    """
+        Benchmark on target device
+    """
+    logger.info("Benchmark step start.")
+
+    benchmark_model: Model = benchmarker.upload_model(tflite_model)
+    benchmark_task: BenchmarkTask = benchmarker.benchmark_model(
+        model=benchmark_model,
+        target_device_name=TARGET_DEVICE_NAME,
+        data_type=DATA_TYPE,
+        hardware_type=HardwareType.HELIUM,
+        wait_until_done=True
+    )
+
+    logger.info(f"model inference latency: {benchmark_task.latency} ms")


### PR DESCRIPTION
Notion link: https://www.notion.so/notaai/ModelZoo-for-Arm-M85-U55-d503998fb1424513b877906e9125d562?pvs=4

목적
---
- Target device로 M85, U55 를 선택할 수 있도록 하고 동시에 helium 적용을 선택할 수 있게 한다.
- tflite converting 및 device benchmark step을 추가한다.

변경 사항
---
- device argument M85, U55, and with/without Helium 추가 
- PyNetsPresso 를 사용해 onnx → full int8 tflite convert
- PyNetsPresso 를 통해서 tflite를 타겟 디바이스에서 latency 측정
  - Notion: https://www.notion.so/notaai/M85-U55-with-without-helium-test-ad97b35f33334512af5cf977b86affe5?pvs=4
- README 수정

참조
---
